### PR TITLE
Renamed manifest hostname to baseurl

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -15,7 +15,7 @@ Using our [sample implementation](../README.md#using-the-sample-implementation),
 ## How can I verify XPOC-protected content?
 
 There are two mechanisms to verify XPOC-protected content:
-1. By inspecting a content owner's XPOC manifest (located on their website at `https://<hostname>/xpoc-manifest.json`) to discover their associated accounts on various platforms (e.g., YouTube, X/Twitter, Facebook, etc.) and specific content items (e.g., posts, videos, etc.), or
+1. By inspecting a content owner's XPOC manifest (located on their website at `https://<baseurl>/xpoc-manifest.json`) to discover their associated accounts on various platforms (e.g., YouTube, X/Twitter, Facebook, etc.) and specific content items (e.g., posts, videos, etc.), or
 2. By dereferencing a XPOC URI on a platform account or content page to locate the owner's XPOC manifest and verify if the XPOC resource is indeed listed in the manifest.
 
 Using our [sample implementation](../README.md#using-the-sample-implementation), you can do the former by using the XPOC validator portal (by entering the owner's website), and the later by using the portal (by entering a resource URI) or the web browser extension (by right-clicking on a XPOC URI).
@@ -26,7 +26,7 @@ XPOC confirms that an account is linked with a known website, and that a piece o
 
 ## What is a XPOC URI?
 
-A XPOC URI is a string starting with `xpoc://` prefix followed by a web resolvable hostname. The prefix helps validators to recognize XPOC resources on a HTML page. A XPOC validator fetches the XPOC manifest by replacing the `xpoc://` prefix with `https://` and appending `/xpoc-manifest.json` to the URI.
+A XPOC URI is a string starting with `xpoc://` prefix followed by a base url (a hostname (domain) followed by an optional path). The prefix helps validators to recognize XPOC resources on a HTML page. A XPOC validator fetches the XPOC manifest by replacing the `xpoc://` prefix with `https://` and appending `/xpoc-manifest.json` to the URI.
 
 ## Can a piece of content be associated with more than one XPOC URI?
 

--- a/doc/xpoc-specification.md
+++ b/doc/xpoc-specification.md
@@ -33,7 +33,7 @@ A XPOC manifest is a JSON file with the following schema:
 ```
 {
     name: string,
-    hostname: string,
+    baseurl: string,
     version: string,
     accounts: [
         {
@@ -58,7 +58,7 @@ A XPOC manifest is a JSON file with the following schema:
 
 where:
 * `name` is the human-readable name of the Owner,
-* `hostname` is the hostname of the Owner's website, i.e., the top-level URL without the protocol header (e.g., `example.com`),
+* `baseurl` is the base url of the Owner's website, i.e., the hostname (domain) followed by an optional path, without the protocol header (e.g., `example.com` or `example.com/some/path`),
 * `version` is the version number of the specification used to generate the manifest; currently `0.1.1`.
 * `accounts` is an array of the Owner's platform accounts, JSON objects with the following properties:
   * `platform` is the name of the hosting platform,
@@ -92,7 +92,7 @@ Alex creates a manifest and makes it available at `https://alexexample.com/xpoc-
 ```json
 {
     "name": "Alex Example",
-    "hostname": "alexexample.com",
+    "baseurl": "alexexample.com",
     "version": "0.1.1",
     "accounts": [],
     "content": []
@@ -126,13 +126,13 @@ Alex then adds the following JSON object to the manifest's `content` array:
 ### Account validation
 
 A verifier can check that a X (formerly Twitter) account is indeed owned by `alexexample.com` by:
-1. Parsing the XPOC URI on the account page to get the `alexexample.com` hostname,
+1. Parsing the XPOC URI on the account page to get the `alexexample.com` base URL,
 2. Retrieving the XPOC manifest from `https://alexexample.com/xpoc-manifest.json`, and
 3. Verifying that the account page is listed in the manifest's `accounts` property.
 
 ### Content validation
 
 A verifier can check that the Youtube video posted by `@AlexExample` is indeed from `alexexample.com` by:
-1. Parsing the XPOC URI to get the `alexexample.com` hostname,
+1. Parsing the XPOC URI to get the `alexexample.com` base URL,
 2. Retrieving the XPOC manifest from `https://alexexample.com/xpoc-manifest.json`, and
 3. Verifying that the video URL is listed in the manifest's `content` property.

--- a/samples/browser-extension/background.js
+++ b/samples/browser-extension/background.js
@@ -66,7 +66,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
                 console.log('Content found in manifest', matchingAccount);
                 const result = {
                     name: manifest.name,
-                    hostname: manifest.hostname,
+                    baseurl: manifest.baseurl,
                     version: manifest.version,
                     account: matchingAccount
                 };
@@ -79,7 +79,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
                     console.log('Content found in manifest', matchingContent);
                     const result = {
                         name: manifest.name,
-                        hostname: manifest.hostname,
+                        baseurl: manifest.baseurl,
                         version: manifest.version,
                         content: matchingContent
                     };

--- a/samples/browser-extension/content.js
+++ b/samples/browser-extension/content.js
@@ -33,7 +33,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                 "\n" +
                 "Origin information\n" +
                 "  Name: " + request.result.name + "\n" +
-                "  Website: " + request.result.hostname + "\n" +
+                "  Website: " + request.result.baseurl + "\n" +
                 "\n" +
                 "Account information\n" +
                 "  URL: " + request.result.account.url + "\n" +
@@ -48,7 +48,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                 "\n" +
                 "Origin information\n" +
                 "  Name: " + request.result.name + "\n" +
-                "  Website: " + request.result.hostname + "\n" +
+                "  Website: " + request.result.baseurl + "\n" +
                 "\n" +
                 "Content information\n" +
                 "  Title: " + request.result.content.title + "\n" +

--- a/samples/client-side-html/package-lock.json
+++ b/samples/client-side-html/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.2"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",

--- a/samples/client-side-html/public/xpoc-common.js
+++ b/samples/client-side-html/public/xpoc-common.js
@@ -10,7 +10,7 @@ function clearError() {
     errMsgElem.style.display = 'none'; 
 }
 
-// fetch the xpoc manifest from the given hostname or XPOC URI
+// fetch the xpoc manifest from the given base URL or XPOC URI
 async function fetchXpocManifest(location) {
     // if location is a XPOC URI (starts with xpoc://), replace the protocol with https:// and remove the trailing '!' (if present)
     location = location.replace(/^xpoc:\/\//, 'https://').replace(/!$/, '');

--- a/samples/client-side-html/public/xpoc-editor.html
+++ b/samples/client-side-html/public/xpoc-editor.html
@@ -47,8 +47,8 @@
                     <td><input type="text" id="manifestName" onchange="manifest.name = this.value"></td>
                 </tr>
                 <tr>
-                    <td><label for="manifestHostname">Hostname:</label><span class="info-tooltip">i<span class="tooltip-text">Hostname of the XPOC manifest location (e.g., "https://example.com")</span></span></td>
-                    <td><input type="text" id="manifestHostname" onchange="manifest.hostname = this.value"></td>
+                    <td><label for="manifestBaseUrl">Base URL:</label><span class="info-tooltip">i<span class="tooltip-text">Base URL of the XPOC manifest location (e.g., "example.com" or "example.com/path")</span></span></td>
+                    <td><input type="text" id="manifestBaseUrl" onchange="manifest.baseurl = this.value"></td>
                 </tr>
                 <tr>
                     <td><label for="manifestVersion">Version:</label><span class="info-tooltip">i<span class="tooltip-text">Specification version of the XPOC manifest. Latest version is 0.1.1</span></span></td>
@@ -79,7 +79,7 @@
     <script>
         let manifest = {
             name: "",
-            hostname: "",
+            baseurl: "",
             version: "0.1.1",
             accounts: [],
             content: []
@@ -88,14 +88,14 @@
         function initializeManifestInfo() {
             clearError();
             document.getElementById('manifestName').value = manifest.name || '';
-            document.getElementById('manifestHostname').value = manifest.hostname || '';
+            document.getElementById('manifestBaseUrl').value = manifest.baseurl || '';
             document.getElementById('manifestVersion').value = manifest.version || '0.1.1';
         }
 
         function createNewManifest() {
             manifest = {
                 name: "",
-                hostname: "",
+                baseurl: "",
                 version: "0.1.1",
                 accounts: [],
                 content: []

--- a/samples/client-side-html/public/xpoc-verifier.html
+++ b/samples/client-side-html/public/xpoc-verifier.html
@@ -34,8 +34,8 @@
                     <td>${manifest.name}</td>
                 </tr>
                 <tr>
-                    <td><label>Manifest location:</label><span class="info-tooltip">i<span class="tooltip-text">Hostname of the XPOC manifest location</span></span></td>
-                    <td>${manifest.hostname}</td>
+                    <td><label>Manifest location:</label><span class="info-tooltip">i<span class="tooltip-text">Base URL of the XPOC manifest location</span></span></td>
+                    <td>${manifest.baseurl}</td>
                 </tr>
                 <tr>
                     <td><label>Version:</label><span class="info-tooltip">i<span class="tooltip-text">Specification version of the XPOC manifest. Latest version is 0.1.1</span></span></td>
@@ -95,7 +95,7 @@
                     </tr>
                     <tr>
                         <td><label>Account:</label><span class="info-tooltip">i<span class="tooltip-text">Platform account associated with the content</span></span></td>
-                        <td>${content.accout}</td>
+                        <td>${content.account}</td>
                     </tr>
                     <tr>
                         <td><label>Timestamp:</label><span class="info-tooltip">i<span class="tooltip-text">Content creation time in UTC</span></span></td>

--- a/samples/client-side-html/public/xpoc-viewer.html
+++ b/samples/client-side-html/public/xpoc-viewer.html
@@ -12,7 +12,7 @@
     <h1>XPOC Manifest Viewer</h1>
 
     <label>Enter the website hosting the XPOC manifest: </label>
-    <input type="text" id="hostnameInput" placeholder="Enter hostname...">
+    <input type="text" id="urlInput" placeholder="Enter URL...">
     <button onclick="fetchManifest()">View</button>
 
     <div class="error" id="errorMsg"></div>
@@ -31,17 +31,17 @@
     <script src="xpoc-common.js"></script>
     <script>
         function fetchManifest() {
-            let hostname = document.getElementById('hostnameInput').value.trim();
-            if (!hostname) {
-                showError('Please enter a hostname.');
+            let url = document.getElementById('urlInput').value.trim();
+            if (!url) {
+                showError('Please enter a URL.');
                 return;
             }
 
-            fetchXpocManifest(hostname)
+            fetchXpocManifest(url)
                 .then(data => {if (data) { displayManifest(data) }} )
                 .catch(error => {
                     console.log('manifest display error', error);
-                    showError(`Error parsing the XPOC manifest from ${hostname}.`);
+                    showError(`Error parsing the XPOC manifest from ${url}.`);
                     document.getElementById('accountsTable').innerHTML = '';
                     document.getElementById('contentTable').innerHTML = '';
                 });
@@ -59,8 +59,8 @@
                 <td>${data.name}</td>
             </tr>
             <tr>
-                <td><label for="manifestHostname">Hostname:</td>
-                <td>${data.hostname}</td>
+                <td><label for="manifestBaseUrl">Base URL:</td>
+                <td>${data.baseurl}</td>
             </tr>
             <tr>
                 <td><label for="manifestVersion">Version:</td>

--- a/samples/server-portal/public/viewer.html
+++ b/samples/server-portal/public/viewer.html
@@ -19,8 +19,8 @@
                 This page is a viewer for Cross-Platform Origin of Content (XPOC) manifests.
             </p>
             <div class="scrollable-content">
-                <p>Enter the hostname of the site to lookup.</p> 
-                <input type="text" id="urlInput" placeholder="Enter hostname" required class="styled-input">
+                <p>Enter the base URL of the site to lookup.</p> 
+                <input type="text" id="urlInput" placeholder="Base URL" required class="styled-input">
                 <button onclick="fetchManifest()">View</button>
                 <div id="output" class="section"></div>
             </div>

--- a/samples/server-portal/public/xpoc-validator.js
+++ b/samples/server-portal/public/xpoc-validator.js
@@ -41,7 +41,7 @@ function displayManifest(manifestData) {
     
     let manifestHtml = `<div class="main-content"><h3>Manifest</h3><ul>`;
     manifestHtml += `<li><strong>Name:</strong> ${manifestData.name}</li>`;
-    manifestHtml += `<li><strong>Hostname:</strong> ${manifestData.url}</li>`;
+    manifestHtml += `<li><strong>Base URL:</strong> ${manifestData.baseurl}</li>`;
     manifestHtml += "</ul></div>";
 
     let accountsHtml = `<div class="main-content"><h3>Accounts</h3><ul>`;

--- a/samples/server-portal/src/xpoc.ts
+++ b/samples/server-portal/src/xpoc.ts
@@ -24,7 +24,7 @@ export type ContentItem = {
 
 export type XPOCManifest = {
   name: string;
-  hostname: string;
+  baseurl: string;
   version: string;
   accounts: Account[];
   content: ContentItem[];


### PR DESCRIPTION
We need to support manifest hosted by accounts under a path (e.g., https://organization.org/username). `hostname` is therefore incorrect; renamed the manifest field to `baseurl`.