### PR TITLE
Separated account and content retrieval flag in platform

### DIFF
--- a/lib/src/manifest.test.ts
+++ b/lib/src/manifest.test.ts
@@ -108,60 +108,74 @@ describe('manifest file operations', () => {
 describe('platform operations', () => {
     test('platform account URL validation', () => {
         // YouTube test
-        expect(Manifest.isSuportedPlatformAccountUrl('https://www.youtube.com/@accountname/about')).toBe(true);
+        expect(Manifest.isSuportedAccountUrl('https://www.youtube.com/@accountname/about')).toBe(true);
         // X/Twitter test
-        expect(Manifest.isSuportedPlatformAccountUrl('https://twitter.com/accountname')).toBe(true);
+        expect(Manifest.isSuportedAccountUrl('https://twitter.com/accountname')).toBe(true);
         // Facebook test
-        expect(Manifest.isSuportedPlatformAccountUrl('https://www.facebook.com/accountname')).toBe(true);
+        expect(Manifest.isSuportedAccountUrl('https://www.facebook.com/accountname')).toBe(true);
         // Instagram test
-        expect(Manifest.isSuportedPlatformAccountUrl('https://www.instagram.com/accountname/')).toBe(true);
+        expect(Manifest.isSuportedAccountUrl('https://www.instagram.com/accountname/')).toBe(true);
         // Medium test
-        expect(Manifest.isSuportedPlatformAccountUrl('https://medium.com/@accountname')).toBe(true);
+        expect(Manifest.isSuportedAccountUrl('https://medium.com/@accountname')).toBe(true);
         // unsupported platform
-        expect(Manifest.isSuportedPlatformAccountUrl('https://www.notaplatform.com/accountname')).toBe(false);
+        expect(Manifest.isSuportedAccountUrl('https://www.notaplatform.com/accountname')).toBe(false);
     });
 
     test('platform content URL validation', () => {
         // YouTube test
-        expect(Manifest.isSuportedPlatformContentUrl('https://www.youtube.com/watch?v=abcdef12345')).toBe(true);
+        expect(Manifest.isSuportedContentUrl('https://www.youtube.com/watch?v=abcdef12345')).toBe(true);
         // X/Twitter test
-        expect(Manifest.isSuportedPlatformContentUrl('https://twitter.com/accountname/status/1234567890123456789')).toBe(true);
+        expect(Manifest.isSuportedContentUrl('https://twitter.com/accountname/status/1234567890123456789')).toBe(true);
         // Facebook test
-        expect(Manifest.isSuportedPlatformContentUrl('https://www.facebook.com/accountname/photos/123456789012345')).toBe(true);
+        expect(Manifest.isSuportedContentUrl('https://www.facebook.com/accountname/photos/123456789012345')).toBe(true);
         // Instagram test
-        expect(Manifest.isSuportedPlatformContentUrl('https://www.instagram.com/p/ABCDEF12345/')).toBe(true);
+        expect(Manifest.isSuportedContentUrl('https://www.instagram.com/p/ABCDEF12345/')).toBe(true);
         // Medium test
-        expect(Manifest.isSuportedPlatformContentUrl('https://medium.com/@accountname/title-abcdef123456')).toBe(true);
+        expect(Manifest.isSuportedContentUrl('https://medium.com/@accountname/title-abcdef123456')).toBe(true);
         // unsupported platform
-        expect(Manifest.isSuportedPlatformContentUrl('https://www.notaplatform.com/abc123')).toBe(false);
+        expect(Manifest.isSuportedContentUrl('https://www.notaplatform.com/abc123')).toBe(false);
     });
 
     test('platform account URL extraction', async () => {
         // YouTube test
-        const accountData = await Manifest.getAccountFromUrl('https://www.youtube.com/@christianpaquinmsr');
+        let url = 'https://www.youtube.com/@christianpaquinmsr';
+        expect(Manifest.canFetchAccountFromUrl(url)).toBe(true);
+        const accountData = await Manifest.getAccountFromUrl(url);
         expect(accountData.platform).toBe('YouTube');
         expect(accountData.account).toBe('christianpaquinmsr');
         expect(accountData.url).toBe('https://www.youtube.com/@christianpaquinmsr/about');
 
         // X/Twitter test (no public access, expect a not supported exception)
-        await expect(Manifest.getAccountFromUrl('https://twitter.com/chpaquin')).rejects.toThrow();
+        url = 'https://twitter.com/chpaquin';
+        expect(Manifest.canFetchAccountFromUrl(url)).toBe(false);
+        await expect(Manifest.getAccountFromUrl(url)).rejects.toThrow();
 
         // Facebook test (no public access, expect a not supported exception)
-        await expect(Manifest.getAccountFromUrl('https://facebook.com/Microsoft')).rejects.toThrow();
+        url = 'https://www.facebook.com/Microsoft';
+        expect(Manifest.canFetchAccountFromUrl(url)).toBe(false);
+        await expect(Manifest.getAccountFromUrl(url)).rejects.toThrow();
 
         // Instagram test (no public access, expect a not supported exception)
-        await expect(Manifest.getAccountFromUrl('https://www.instagram.com/microsoft/')).rejects.toThrow();
+        url = 'https://www.instagram.com/microsoft/';
+        expect(Manifest.canFetchAccountFromUrl(url)).toBe(false);
+        await expect(Manifest.getAccountFromUrl(url)).rejects.toThrow();
 
         // Medium test (not yet implemented (TODO), expect a not supported exception)
-        await expect(Manifest.getAccountFromUrl('https://medium.com/@chpaquin')).rejects.toThrow();
+        url = 'https://medium.com/@chpaquin';
+        expect(Manifest.canFetchAccountFromUrl(url)).toBe(false);
+        await expect(Manifest.getAccountFromUrl(url)).rejects.toThrow();
 
         // unsupported platform
-        await expect(Manifest.getAccountFromUrl('https://www.notaplatform.com/accountname')).rejects.toThrow();
+        url = 'https://www.notaplatform.com/accountname';
+        expect(Manifest.canFetchAccountFromUrl(url)).toBe(false);
+        await expect(Manifest.getAccountFromUrl(url)).rejects.toThrow();
     });
 
     test('platform content URL extraction', async () => {
         // YouTube test
-        const contentData = await Manifest.getContentFromUrl('https://www.youtube.com/watch?v=hDd3t7y1asU');
+        let url = 'https://www.youtube.com/watch?v=hDd3t7y1asU';
+        expect(Manifest.canFetchContentFromUrl(url)).toBe(true);
+        const contentData = await Manifest.getContentFromUrl(url);
         expect(contentData.platform).toBe('YouTube');
         expect(contentData.puid).toBe('hDd3t7y1asU');
         expect(contentData.url).toBe('https://www.youtube.com/watch?v=hDd3t7y1asU');
@@ -169,18 +183,28 @@ describe('platform operations', () => {
         expect(contentData.timestamp).toBe('2023-07-10T00:00:00Z');
 
         // X/Twitter test (no public access, expect a not supported exception)
-        await expect(Manifest.getContentFromUrl('https://twitter.com/chpaquin/status/1694698274618319246')).rejects.toThrow();
+        url = 'https://twitter.com/chpaquin/status/1694698274618319246';
+        expect(Manifest.canFetchContentFromUrl(url)).toBe(false);
+        await expect(Manifest.getContentFromUrl(url)).rejects.toThrow();
 
         // Facebook test (no public access, expect a not supported exception)
-        await expect(Manifest.getContentFromUrl('https://www.facebook.com/Microsoft/photos/a.10150199519298721/10150199519298721/')).rejects.toThrow();
+        url = 'https://www.facebook.com/Microsoft/photos/a.10150199519298721/10150199519298721/';
+        expect(Manifest.canFetchContentFromUrl(url)).toBe(false);
+        await expect(Manifest.getContentFromUrl(url)).rejects.toThrow();
 
         // Instagram test (no public access, expect a not supported exception)
-        await expect(Manifest.getContentFromUrl('https://www.instagram.com/p/CQ7Z1Y1JZ1s/')).rejects.toThrow();
+        url = 'https://www.instagram.com/p/CQ7Z1Y1JZ1s/';
+        expect(Manifest.canFetchContentFromUrl(url)).toBe(false);
+        await expect(Manifest.getContentFromUrl(url)).rejects.toThrow();
 
         // Medium test (not yet implemented (TODO), expect a not supported exception)
-        await expect(Manifest.getContentFromUrl('https://medium.com/@chpaquin/xpoc-test-4fecf28be9a8')).rejects.toThrow();
+        url = 'https://medium.com/@chpaquin/xpoc-test-4fecf28be9a8';
+        expect(Manifest.canFetchContentFromUrl(url)).toBe(false);
+        await expect(Manifest.getContentFromUrl(url)).rejects.toThrow();
 
         // unsupported platform
-        await expect(Manifest.getContentFromUrl('https://www.notaplatform.com/abc123')).rejects.toThrow();
+        url = 'https://www.notaplatform.com/abc123';
+        expect(Manifest.canFetchContentFromUrl(url)).toBe(false);
+        await expect(Manifest.getContentFromUrl(url)).rejects.toThrow();
     });
 });

--- a/lib/src/manifest.ts
+++ b/lib/src/manifest.ts
@@ -90,14 +90,28 @@ export class Manifest {
     }
 
     /**
-     * Checks if a URL is an account URL from a supported platform. If so,
-     * getAccountFromUrl() can be used to extract the account data.
+     * Checks if a URL is an account URL from a supported platform.
      * @param url URL to check.
      * @returns true if the URL is a supported platform account URL.
      */
-    static isSuportedPlatformAccountUrl(url: string): boolean {
+    static isSuportedAccountUrl(url: string): boolean {
         for (const platform of platforms) {
             if (platform.isValidAccountUrl(url)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if account data can be retrieved from the URL. If so,
+     * getAccountFromUrl() can be called.
+     * @param url URL to check.
+     * @returns true if account data can be retrieved from the URL.
+     */
+    static canFetchAccountFromUrl(url: string): boolean {
+        for (const platform of platforms) {
+            if (platform.isValidAccountUrl(url) && platform.CanFetchAccountData) {
                 return true;
             }
         }
@@ -124,14 +138,28 @@ export class Manifest {
     }
 
    /**
-     * Checks if a URL is a content URL from a supported platform. If so,
-     * getContentFromUrl() can be used to extract the content data.
+     * Checks if a URL is a content URL from a supported platform.
      * @param url URL to check.
      * @returns true if the URL is a supported platform content URL.
      */
-   static isSuportedPlatformContentUrl(url: string): boolean {
+   static isSuportedContentUrl(url: string): boolean {
         for (const platform of platforms) {
             if (platform.isValidContentUrl(url)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if content data can be retrieved from the URL. If so,
+     * getContentFromUrl() can be called.
+     * @param url URL to check.
+     * @returns true if content data can be retrieved from the URL.
+     */
+    static canFetchContentFromUrl(url: string): boolean {
+        for (const platform of platforms) {
+            if (platform.isValidContentUrl(url) && platform.CanFetchContentData) {
                 return true;
             }
         }

--- a/lib/src/platform.test.ts
+++ b/lib/src/platform.test.ts
@@ -386,7 +386,7 @@ for (const platformTestData of platformTestDataArray) {
             }
         });
 
-        if (platform.CanFetchData) {
+        if (platform.CanFetchAccountData) {
             test(`${platformName} account fetch test`, async () => {
                 const sampleAccount = platformTestData.sampleAccountData;
                 if (sampleAccount) {
@@ -399,7 +399,9 @@ for (const platformTestData of platformTestDataArray) {
                     throw new Error(`No sample account data for ${platformName}`);
                 }
             });
+        }
 
+        if (platform.CanFetchContentData) {
             test(`${platformName} content fetch test`, async () => {
                 const sampleContent = platformTestData.sampleContentData;
                 if (sampleContent) {

--- a/lib/src/platform.ts
+++ b/lib/src/platform.ts
@@ -35,9 +35,13 @@ export abstract class Platform {
     // canonical hostname
     public CanonicalHostname: string;
 
-    // returns true if the platform is accessible (either publicly, or through pre-configured API access)
-    // if true, @see getAccountData and @see getContentData can be called
-    public CanFetchData: boolean;
+    // returns true if the platform account data is accessible (either publicly, or through pre-configured API access)
+    // if true, @see getAccountData can be called
+    public CanFetchAccountData: boolean;
+
+    // returns true if the platform content data is accessible (either publicly, or through pre-configured API access)
+    // if true, @see getContentData can be called
+    public CanFetchContentData: boolean;
 
     // regex strings used to validate and canonicalize hostname URLs
     protected regexHostnameString: string;
@@ -48,11 +52,12 @@ export abstract class Platform {
     // regex strings used to validate and canonicalize content URLs
     protected contentRegexString: string;
 
-    constructor(displayName: string, canonicalHostname: string, canFetchData: boolean,
+    constructor(displayName: string, canonicalHostname: string, canFetchAccountData: boolean, canFetchContentData: boolean,
                 regexHostnameString: string, accountRegexStringSuffix: string, contentRegexStringSuffix: string) {
         this.DisplayName = displayName;
         this.CanonicalHostname = canonicalHostname;
-        this.CanFetchData = canFetchData;
+        this.CanFetchAccountData = canFetchAccountData;
+        this.CanFetchContentData = canFetchContentData;
         this.regexHostnameString = regexHostnameString;
         this.accountRegexString = regexHostnameString + accountRegexStringSuffix;
         this.contentRegexString = regexHostnameString + contentRegexStringSuffix;
@@ -110,7 +115,7 @@ const findXpocUri = (text:string | undefined) => {
 // an API key and a Google account.
 export class YouTube extends Platform {
     constructor() {
-        super('YouTube', 'https://www.youtube.com', true,
+        super('YouTube', 'https://www.youtube.com', true, true,
             // matches YouTube URLs, with or without www. or m. subdomains
             "^https?://(?:www\\.|m\\.)?(youtube\\.com|youtu\\.be)",
             // matches YouTube account URLs, with an optional 'about/' path
@@ -210,7 +215,7 @@ export class YouTube extends Platform {
 export class XTwitter extends Platform {
 
     constructor() {
-        super('X/Twitter', 'https://twitter.com', false,
+        super('X/Twitter', 'https://twitter.com', false, false,
         // matches X/Twitter URLs, with or without a www. subdomain (TODO: is the www. subdomain ever used?)
         "^https?://(?:www\\.)?(twitter\\.com|x\\.com)",
         // matches X/Twitter account URLs, with an optional '@' prefix (gets removed by redirect)
@@ -269,7 +274,7 @@ export class XTwitter extends Platform {
 export class Facebook extends Platform {
 
     constructor() {
-        super('Facebook', 'https://www.facebook.com', false,
+        super('Facebook', 'https://www.facebook.com', false, false,
         // matches Facebook URLs, with or without www. or m. subdomains
         `^https?://(?:www\\.|m\\.)?(facebook\\.com|fb\\.com)`,
         // matches Facebook account URLs, with an optional 'about/' path
@@ -354,7 +359,7 @@ export class Facebook extends Platform {
 // and content URLs; this requires API access.
 export class Instagram extends Platform {
     constructor() {
-        super('Instagram', 'https://www.instagram.com', false,
+        super('Instagram', 'https://www.instagram.com', false, false,
         // matches Instagram URLs, with or without www. or m. subdomains
         `^https?://(?:www\\.|m\\.)?(instagram\\.com)`,
         // matches Instagram account URLs
@@ -436,7 +441,7 @@ export class Medium extends Platform {
 
     constructor() {
         super('Medium', 'https://medium.com',
-            false, // some (most) stories are publicly available, so we could make that true (TODO)
+            false, false, // some (most) accounts and stories are publicly available, so we could make these true (TODO)
             // not using the base class regexp strings, because of how Medium URLs are structured
             '', '', ''
         );


### PR DESCRIPTION
Separated account and content retrieval flag in platform class, since they could have different access control for account pages and content pages.

* Split `CanFetchData` boolean into `CanFetchPlatformData` and `CanFetchContentData`.
* Added corresponding `canFetch[Account|Content]FromUrl` functions in `manifest.ts`
* Renamed some functions for uniformity