### PR TITLE
Bump spec version to v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cross-Platform Origin of Content (XPOC) Framework
 
-_This is a pre-release preview of the framework, currently at version 0.1.1. The specification and sample implementations might change significantly as we continue its development and receive feedback._
+_This is a pre-release preview of the framework, currently at version 0.1.2. The specification and sample implementations might change significantly as we continue its development and receive feedback._
 
 This project introduces the Cross-Platform Origin of Content (XPOC) framework, along with a sample implementation.
 

--- a/doc/xpoc-specification.md
+++ b/doc/xpoc-specification.md
@@ -1,6 +1,6 @@
 # Cross-Platform Origin of Content (XPOC) Framework Specification
 
-This document specifies the Cross-Platform Origin of Content (XPOC) framework, to enable interoperable implementation. The current version of the specification is 0.1.1.
+This document specifies the Cross-Platform Origin of Content (XPOC) framework, to enable interoperable implementation. The current version of the specification is 0.1.2.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119](https://www.rfc-editor.org/rfc/rfc2119).
 
@@ -37,19 +37,18 @@ A XPOC manifest is a JSON file with the following schema:
     version: string,
     accounts: [
         {
+            account: string
             platform: string,
             url: string,
-            account: string
         }
     ]
     content: [
         {
-            title: string, (optional),
-            desc: string (optional),
-            url: string,
-            platform: string,
-            puid: string (optional),
             account: string,
+            platform: string,
+            url: string,
+            desc: string (optional),
+            puid: string (optional),
             timestamp: string (optional)
         }, ...
     ]
@@ -60,18 +59,17 @@ where:
 
 -   `name` is the human-readable name of the Owner,
 -   `baseurl` is the base url of the Owner's website, i.e., the hostname (domain) followed by an optional path, without the protocol header (e.g., `example.com` or `example.com/some/path`),
--   `version` is the version number of the specification used to generate the manifest; currently `0.1.1`.
+-   `version` is the version number of the specification used to generate the manifest; currently `0.1.2`.
 -   `accounts` is an array of the Owner's platform accounts, JSON objects with the following properties:
-    -   `platform` is the name of the hosting platform,
-    -   `url` is the URL of the account page, and
-    -   `account` is the platform-specific account name.
+    -   `account` is the platform-specific account name,
+    -   `platform` is the name of the hosting platform, and
+    -   `url` is the URL of the account page.
 -   `content` is an array of XPOC content items, JSON objects with the following properties:
-    -   `title` is the label for the content item,
-    -   `desc` is a description of the content item,
-    -   `url` is the URL of the content item on a hosting platform,
+    -   `account` is the platform-specific account name which owns the content item,
     -   `platform` is the name of the hosting platform,
-    -   `puid` is a platform-specific unique identifier of the hosted content,
-    -   `account` is the platform-specific account name which owns the content item, and
+    -   `url` is the URL of the content item on a hosting platform,
+    -   `desc` is a description of the content item,
+    -   `puid` is a platform-specific unique identifier of the hosted content, and
     -   `timestamp` is the creation time of the item, represented in the ISO 8601 date-time format (YYYY-MM-DDTHH:MM:SSZ) in UTC. For example, Sept 1st, 2023, 10:30 UTC is represented as "2023-09-01T10:30:00Z".
 
 Different platforms represent content differently; implementation SHOULD follow the [guidelines](./platforms.md) on how to encode platform-specific data for some popular hosting platforms.
@@ -98,7 +96,7 @@ Alex creates a manifest and makes it available at `https://alexexample.com/xpoc-
 {
     "name": "Alex Example",
     "baseurl": "alexexample.com",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "accounts": [],
     "content": []
 }
@@ -110,14 +108,14 @@ Alex adds their Facebook account name `alex.example` and their X/Twitter account
 
 ```json
 {
+    "account": "alex.example",
     "platform": "Facebook",
-    "url": "https://facebook.com/alex.example",
-    "account": "alex.example"
+    "url": "https://facebook.com/alex.example"
 },
 {
+    "account": "ExAlex",
     "platform": "X",
-    "url": "https://twitter.com/ExAlex",
-    "account": "ExAlex"
+    "url": "https://twitter.com/ExAlex"
 }
 ```
 
@@ -128,12 +126,11 @@ Alex's conference video is posted on YouTube at `https://www.youtube.com/watch?v
 Alex then adds the following JSON object to their manifest's `content` array:
 
 ```json
-    "title": "Cool conference panel",
-    "desc": "My panel at the Cool conference",
-    "url": "https://www.youtube.com/watch?v=abcdef12345",
-    "platform": "YouTube",
-    "puid": "abcde12345",
     "account": "@CoolConf",
+    "platform": "YouTube",
+    "url": "https://www.youtube.com/watch?v=abcdef12345",
+    "desc": "My panel at the Cool conference",
+    "puid": "abcde12345",
     "timestamp": "2023-08-24T08:45:00Z"
 ```
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpoc-ts-lib",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TypeScript reference implementation for the XPOC framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/lib/src/manifest.ts
+++ b/lib/src/manifest.ts
@@ -41,7 +41,7 @@ export type XPOCManifest = {
  */
 export class Manifest {
     manifest: XPOCManifest;
-    static LatestVersion = '0.1.1';
+    static LatestVersion = '0.1.2';
 
     constructor(manifest: XPOCManifest) {
         this.manifest = manifest;

--- a/lib/testdata/testmanifest.json
+++ b/lib/testdata/testmanifest.json
@@ -1,7 +1,7 @@
 {
     "name": "A test name",
     "url": "https://example.com",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"accounts": [
 		{
 			"platform": "X",
@@ -32,7 +32,7 @@
     "content": [
 		{
 			"timestamp": "2023-07-10T00:00:00Z",
-			"title": "XPOC test", 
+			"desc": "XPOC test", 
 			"url": "https://www.youtube.com/watch?v=abcdef12345",
 			"platform": "YouTube",
 			"puid": "hDd3t7y1asU",
@@ -40,7 +40,7 @@
 		},
         {
 			"timestamp": "2023-07-11T00:00:00Z",
-			"title": "a test title", 
+			"desc": "a test title", 
 			"url": "https://twitter.com/chpaquin/status/1234567890123456789",
 			"platform": "X",
 			"puid": "1234567890123456789",
@@ -48,7 +48,7 @@
 		},
         {
 			"timestamp": "2023-07-12T00:00:00Z",
-			"title": "a test picture", 
+			"desc": "a test picture", 
 			"url": "https://www.facebook.com/photo/?fbid=123456789012345",
 			"platform": "Facebook",
 			"puid": "123456789012345",
@@ -56,7 +56,7 @@
 		},
 		{
 			"timestamp": "2023-07-13T00:00:00Z",
-			"title": "a test picture", 
+			"desc": "a test picture", 
 			"url": "https://www.instagram.com/p/ABCDE12345/",
 			"platform": "Instagram",
 			"puid": "ABCDE12345",
@@ -64,7 +64,7 @@
 		},
 		{
 			"timestamp": "2023-07-14T00:00:00Z",
-			"title": "a test story", 
+			"desc": "a test story", 
 			"url": "https://medium.com/@a_md_test_account/a-test-story-abcdef123456",
 			"platform": "Medium",
 			"puid": "abcdef123456",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "XPOC framework",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cross-Platform Origin of Content (XPOC) framework",
   "scripts": {
     "lint": "eslint './**/*.{ts,tsx,js,jsx,md}' --fix",

--- a/samples/browser-extension/manifest.json
+++ b/samples/browser-extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Cross-Platform Origin Content Extension",
-    "version": "0.0.1",
+    "version": "0.1.2",
     "description": "Validates XPOC-protected content",
     "permissions": [
         "activeTab",

--- a/samples/browser-extension/package.json
+++ b/samples/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpoc-browser-extension",
-  "version": "0.0.1",
+  "version": "0.1.2",
   "description": "Cross-Platform Origin of Content Browser Extension",
   "license": "MIT"
 }

--- a/samples/client-side-html/public/xpoc-editor.html
+++ b/samples/client-side-html/public/xpoc-editor.html
@@ -51,7 +51,7 @@
                     <td><input type="text" id="manifestBaseUrl" onchange="manifest.baseurl = this.value"></td>
                 </tr>
                 <tr>
-                    <td><label for="manifestVersion">Version:</label><span class="info-tooltip">i<span class="tooltip-text">Specification version of the XPOC manifest. Latest version is 0.1.1</span></span></td>
+                    <td><label for="manifestVersion">Version:</label><span class="info-tooltip">i<span class="tooltip-text">Specification version of the XPOC manifest. Latest version is 0.1.2</span></span></td>
                     <td><input type="text" id="manifestVersion" onchange="manifest.version = this.value"></td>
                 </tr>
             </tbody>
@@ -77,10 +77,12 @@
 
     <script src="xpoc-common.js"></script>
     <script>
+        const currentVersion = "0.1.2";
+
         let manifest = {
             name: "",
             baseurl: "",
-            version: "0.1.1",
+            version: currentVersion,
             accounts: [],
             content: []
         };
@@ -89,14 +91,14 @@
             clearError();
             document.getElementById('manifestName').value = manifest.name || '';
             document.getElementById('manifestBaseUrl').value = manifest.baseurl || '';
-            document.getElementById('manifestVersion').value = manifest.version || '0.1.1';
+            document.getElementById('manifestVersion').value = manifest.version || currentVersion;
         }
 
         function createNewManifest() {
             manifest = {
                 name: "",
                 baseurl: "",
-                version: "0.1.1",
+                version: currentVersion,
                 accounts: [],
                 content: []
             };

--- a/samples/client-side-html/public/xpoc-verifier.html
+++ b/samples/client-side-html/public/xpoc-verifier.html
@@ -38,7 +38,7 @@
                     <td>${manifest.baseurl}</td>
                 </tr>
                 <tr>
-                    <td><label>Version:</label><span class="info-tooltip">i<span class="tooltip-text">Specification version of the XPOC manifest. Latest version is 0.1.1</span></span></td>
+                    <td><label>Version:</label><span class="info-tooltip">i<span class="tooltip-text">Specification version of the XPOC manifest. Latest version is 0.1.2</span></span></td>
                     <td>${manifest.version}</td>
                 </tr>
                 </tbody>

--- a/samples/xpoc-manifest.json
+++ b/samples/xpoc-manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "XPOC framework sample",
     "url": "https://raw.githubusercontent.com/microsoft/xpoc-framework/main/samples",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"accounts": [
 		{
 			"platform": "X",
@@ -12,7 +12,7 @@
     "content": [
 		{
 			"timestamp": "2023-07-10T00:00:00Z",
-			"title": "XPOC test", 
+			"desc": "XPOC test", 
 			"url": "https://www.youtube.com/watch?v=hDd3t7y1asU",
 			"platform": "YouTube",
 			"puid": "hDd3t7y1asU",


### PR DESCRIPTION
Minor tweaks to manifest schema: removed "title" from content ("desc" is enough), reordered JSON properties (leaving optional at the end). Updated code.