### PR TITLE
Remove duplicated lib build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,7 @@ jobs:
 
       - name: Build (only for server-backend)
         if: matrix.sample == 'server-backend'
-        # TODO: build lib here because the lib/dist is not available. Why not?
         run: | 
-          cd lib && npm install && npm run build && cd ..
           cd samples/server-backend && npm run build
 
       - name: Start Server and Check


### PR DESCRIPTION
* Remove lib build instruction in server sample build; refactored CI file should now build the lib correctly