### PR TITLE
Re-init manifest after clicking "new"

### DIFF
--- a/samples/client-side-html/public/xpoc-editor.html
+++ b/samples/client-side-html/public/xpoc-editor.html
@@ -107,11 +107,16 @@
             clearError();
             document.getElementById('manifestName').value = manifest.name || '';
             document.getElementById('manifestBaseUrl').value = manifest.baseurl || '';
-            document.getElementById('manifestVersion').value = manifest.version || currentVersion;
+            document.getElementById('manifestVersion').value = currentVersion; // always save to latest version
             document.getElementById('manifestUpdated').value = getCurrentIsoTime();
         }
 
         function createNewManifest() {
+            // Re-initialize the manifest fields (if edited previously)
+            manifest.name = "";
+            manifest.baseurl = "";
+            manifest.accounts = [];
+            manifest.content = [];
             // Display the initialized manifest info and clear tables
             initializeManifestInfo();
             updateAccountsTable();
@@ -281,6 +286,10 @@
         }
 
         function saveToFile() {
+            // Update timestamp
+            manifest.updated = getCurrentIsoTime();
+            // Make sure we save to the latest version (in case we read an older version)
+            manifest.version = currentVersion;
             // Delete the accounts and content arrays if they are empty
             if (manifest.accounts.length === 0) {
                 delete manifest.accounts;


### PR DESCRIPTION
Re-initialize the manifest fields when clicking the "New" button in the EZ manifest creator sample. Fixes #101.