### PR TITLE
Don't output milliseconds in timestamps

### DIFF
--- a/samples/client-side-html/public/xpoc-editor.html
+++ b/samples/client-side-html/public/xpoc-editor.html
@@ -160,6 +160,8 @@
                     date = null;
                 } else {
                     date = date.toISOString();
+                    // remove milliseconds (if present)
+                    date = date.replace(/\.\d{3}Z$/, 'Z');
                 }
                 // update value in the input field
                 inputElement.value = inputValue;


### PR DESCRIPTION
Remove the milliseconds from the timestamps (per spec) in manifest editor. Fixes #113.