### PR TITLE
Add Cross-Origin error detection in client-side-html

### DIFF
--- a/lib/src/fetch.ts
+++ b/lib/src/fetch.ts
@@ -95,7 +95,12 @@ export async function fetchObject<T>(url: string, options: RequestInit = {}, tim
     timeout = determineTimeout(timeout)
 
     // automatically set the method and content-type if the body is present
-    options = { ...options, method: (options.body == null) ? 'GET' : 'POST', headers: { 'Content-Type': 'application/json' } }
+    // content-type': 'text/plain' will prevent preflight cors requests
+    options = {
+        ...options,
+        headers: { 'content-type': 'text/plain', ...options.headers },
+        method: (options.body == null) ? 'GET' : 'POST'
+    }
 
     const start = Date.now()
     const response = await fetchWithTimeout(url, options, timeout)

--- a/lib/src/manifest.ts
+++ b/lib/src/manifest.ts
@@ -214,7 +214,7 @@ export class ManifestBase {
         return { valid: false, errors };
     }
 
-    static download = async (location: string): Promise<ManifestBase | Error> => {
+    static download = async (location: string): Promise<ManifestBase> => {
         // if location is a XPOC URI (starts with xpoc://), replace the protocol with https:// and remove the trailing '!' (if present)
         location = location.replace(/^xpoc:\/\//, 'https://').replace(/!$/, '');
         // add a https:// prefix if the location doesn't have one
@@ -234,7 +234,7 @@ export class ManifestBase {
 
         if (manifest instanceof Error) {
             console.error(`Error fetching XPOC manifest from ${urlString}: ${JSON.stringify(manifest)}`);
-            return new Error(`Error fetching XPOC manifest from ${urlString}`);
+            throw manifest
         }
 
         return new ManifestBase(manifest)

--- a/lib/test/manifest.test.ts
+++ b/lib/test/manifest.test.ts
@@ -5,6 +5,7 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { Manifest, XPOCManifest, AccountMatchValues, ContentMatchValues } from '../src/manifest';
+import { type FetchError } from '../src/fetch';
 
 describe('manifest file operations', () => {
     let manifest: Manifest;
@@ -211,41 +212,32 @@ describe('manifest download', () => {
     const manifestUrl = 'https://raw.githubusercontent.com/microsoft/xpoc-framework/main/lib/testdata';
 
     test('download: valid manifest', async () => {
-        const manifest = await Manifest.download(manifestUrl);
-        if (manifest instanceof Error) {
-            throw manifest;
-        }
+        const manifest = await Manifest.download(manifestUrl)
         expect(manifest.valid).toBe(true);
     });
 
     test('download: valid manifest (trailing slash)', async () => {
-        const manifest = await Manifest.download(manifestUrl + '/');
-        if (manifest instanceof Error) {
-            throw manifest;
-        }
+        const manifest = await Manifest.download(manifestUrl + '/')
         expect(manifest.valid).toBe(true);
     });
 
     test('download: valid manifest (full path)', async () => {
-        const manifest = await Manifest.download(manifestUrl + '/xpoc-manifest.json');
-        if (manifest instanceof Error) {
-            throw manifest;
-        }
+        const manifest = await Manifest.download(manifestUrl + '/xpoc-manifest.json')
         expect(manifest.valid).toBe(true);
     });
 
     test('download: non-existent url', async () => {
-        const manifest = await Manifest.download(manifestUrl + 'x');
-        const error = manifest as Error;
+        const manifest = await Manifest.download(manifestUrl + 'x').catch((err) => err);
+        const error = manifest as FetchError;
         expect(error).toBeInstanceOf(Error);
-        expect(error.message).toMatch(/^Error fetching XPOC manifest/);
+        expect(error.code).toMatch("NOT-FOUND");
     });
 
     test('download: not JSON file', async () => {
-        const manifest = await Manifest.download('https://raw.githubusercontent.com/microsoft/xpoc-framework/main/lib/README.md');
-        const error = manifest as Error;
+        const manifest = await Manifest.download('https://raw.githubusercontent.com/microsoft/xpoc-framework/main/lib/README.md').catch((err) => err);
+        const error = manifest as FetchError;
         expect(error).toBeInstanceOf(Error);
-        expect(error.message).toMatch(/^Error fetching XPOC manifest/);
+        expect(error.code).toMatch("NOT-FOUND");
     });
 
 });

--- a/samples/client-side-html/public/xpoc-common.js
+++ b/samples/client-side-html/public/xpoc-common.js
@@ -22,6 +22,16 @@ function isoToLocalTime(isoTime) {
 
 // fetch the xpoc manifest from the given base URL or XPOC URI
 async function fetchXpocManifest(location) {
+
+    // if xpoc.Manifest is globally defined, use it to fetch the manifest
+    if(xpoc && xpoc.Manifest) {
+        const manifest = await xpoc.Manifest.download(location)
+        if(manifest instanceof Error) {
+            throw manifest
+        }
+        return manifest.manifest
+    }
+
     // if location is a XPOC URI (starts with xpoc://), replace the protocol with https:// and remove the trailing '!' (if present)
     location = location.replace(/^xpoc:\/\//, 'https://').replace(/!$/, '');
     // add a https:// prefix if the location doesn't have one

--- a/samples/client-side-html/public/xpoc-verifier.html
+++ b/samples/client-side-html/public/xpoc-verifier.html
@@ -28,6 +28,7 @@
     </footer>
 
     <script src="xpoc-common.js"></script>
+    <script src="xpoc.iife.min.js"></script>
     <script>
         function showManifestInfo(manifest) {
             resultBox.innerHTML = `
@@ -142,8 +143,14 @@
                         }
                     }})
                 .catch(error => {
-                    console.log('Manifest error', error);
-                    showError(`Error fetching or parsing the XPOC manifest.`);
+                    if (error?.code === "CORS") {
+                        showError(`Probable Cross-Origin error from ${url}.`);
+                    } else if (error?.code === "NOT-FOUND") {
+                        showError(`Manifest not found at ${url}.`);
+                    } else {
+                        showError(`Error fetching or parsing the XPOC manifest.`);
+                    }
+                    console.log('Manifest error', error);                    
                 });
            }
     </script>

--- a/samples/client-side-html/public/xpoc-viewer.html
+++ b/samples/client-side-html/public/xpoc-viewer.html
@@ -35,6 +35,7 @@
     </footer>
 
     <script src="xpoc-common.js"></script>
+    <script src="xpoc.iife.min.js"></script>
     <script>
         function fetchManifest() {
             let url = document.getElementById('urlInput').value.trim();
@@ -46,8 +47,14 @@
             fetchXpocManifest(url)
                 .then(data => {if (data) { displayManifest(data) }} )
                 .catch(error => {
+                    if (error?.code === "CORS") {
+                        showError(`Probable Cross-Origin error from ${url}.`);
+                    } else if (error?.code === "NOT-FOUND") {
+                        showError(`Manifest not found at ${url}.`);
+                    } else {
+                        showError(`Error parsing the XPOC manifest from ${url}.`);
+                    }
                     console.log('manifest display error', error);
-                    showError(`Error parsing the XPOC manifest from ${url}.`);
                     document.getElementById('accountsTable').innerHTML = '';
                     document.getElementById('contentTable').innerHTML = '';
                 });

--- a/samples/server-backend/src/server.ts
+++ b/samples/server-backend/src/server.ts
@@ -11,7 +11,7 @@ app.use(cors());
 
 // fetches the XPOC manifest from the specified location
 app.get('/fetchManifest', async (req, res) => {
-    const manifest = await Manifest.download(req.query.location as string);
+    const manifest = await Manifest.download(req.query.location as string).catch((err) => err);
     if (manifest instanceof Error) {
         console.error(`Error fetching XPOC manifest from ${req.query.location}: ` + manifest);
         res.status(500).send('Error fetching XPOC manifest');


### PR DESCRIPTION
- Update content-type header of fetch to text/plain to prevent pre-flight OPTIONS check that will cause CORS errors
- Made `xpoc.Manifest.download()` throw its Error instead of returning it be work in a more standard way
- Fixed Manifest tests and server-backend to work with change in Error handling
- Updated client-side-html to us `xpoc.Manifest.download()` instead of `fetch()` directly

Browsers intentionally obscure the specific reasons behind failed HTTPS requests related to cross-origin issues, typically presenting a generic TypeError. To circumvent this, we employ a method where we initially check for a TypeError. If such an error is encountered, we then attempt to resend the request using the 'no-cors' option. If this second request succeeds, it suggests that the initial failure was likely due to CORS restrictions. In such cases, we report back a probable CORS error.

Fixes #88 