### PR TITLE
Fix youtube channel path in browser extension

### DIFF
--- a/samples/browser-extension/src/origin.ts
+++ b/samples/browser-extension/src/origin.ts
@@ -70,7 +70,19 @@ export function getOriginInfo(url: string | undefined): OriginInfo | undefined {
             urlToTest = urlPath.replace(/\/$/, '')
             console.log(`getOriginInfo urlToTest: ${urlToTest}`)   
         }
-    } else {
+    } else if (url.includes('youtube.com/channel/')) {
+        // youtube channel workaround: if the url is a youtube channel, the xpoc library won't recognize
+        // it as a youtube account URL, so we check here
+        const getChannelPath = (url: string) => {
+            const match = url.match(/youtube\.com\/(channel\/[^\s\/?#]+)/)
+            return match ? match[1] : null
+        }
+        platform = 'YouTube'
+        const channelPath = getChannelPath(url)
+        urlToTest = channelPath ? channelPath : ''
+        console.log(`getOriginInfo urlToTest: ${urlToTest}`)   
+    }
+    else {
         console.log(`getOriginInfo url: ${url} is not a supported platform`)
         // check if the url is in the Website table
         platform = 'Website'


### PR DESCRIPTION
YouTube channel URLs are not recognized by our lib, so origin data sources containing such URLs didn't map to youtube resources. Implemented a local work around in the extension to recognize these.