### PR TITLE
Added social trust.txt lookups

### DIFF
--- a/samples/browser-extension/README.md
+++ b/samples/browser-extension/README.md
@@ -56,6 +56,6 @@ The browser extension can be augmented by loading a 3rd party data source to con
 
   ### Using trust.txt files
 
-  The [`trust.txt` specification](https://journallist.net/reference-document-for-trust-txt-specifications) defines a machine-readable text file hosted on a publisher’s domain, which provides information about the publisher’s affiliations, owned media properties, and connections with industry organizations. The `trust.txt` file offers similar functionality as a XPOC manifest. The browser extension can also detect the presence of a trust URI (for example, `trust://example.com!`) file on a visited page, and check if the page is listed in the corresponding `trust.txt` file on the origin domain.
+  The [`trust.txt` specification](https://datatracker.ietf.org/doc/draft-org-trust-relationship-protocol/) defines a machine-readable text file hosted on a publisher’s domain, which provides information about the publisher’s affiliations, owned media properties, and connections with industry organizations. The `trust.txt` file offers similar functionality as a XPOC manifest. The browser extension can also detect the presence of a trust URI (for example, `trust://example.com!`) file on a visited page, and check if the page is listed in the corresponding `trust.txt` file on the origin domain.
 
   

--- a/samples/browser-extension/README.md
+++ b/samples/browser-extension/README.md
@@ -38,7 +38,7 @@ Firefox requires additional extension permissions to download manifests from ext
 
 When visiting a page with a XPOC URI (for example, `xpoc://example.com!`), right-click on the URI text and select **Verify XPOC link** from the context menu. The extension will fetch the corresponding XPOC manifest and determine if the current page's item is indeed listed within it. The extension can automatically find and verify the XPOC URIs in a page if the extension's **Verify XPOC URI automatically** option is enabled (in the popup's Options tab).
 
-## Extension
+## Extension features
 
 ### 3rd party origin data source
 
@@ -53,3 +53,9 @@ The browser extension can be augmented by loading a 3rd party data source to con
 * `contactTables`: an object of contact tables, one per platform (as listed in `source.supportedPlatforms`) and one generic "Website" one:
   * `Website`: an object containing string keys representing websites and integer values representing the index of the associated entry. A key must be a valid website without the `https://` prefix. For example, the `Website` object could contain the key/value pair "`example.com`: 3", where the `source.entry[3]` would represent the entity associated with `example.com`.
   * A supported platform (e.g., `Instagram`, `Facebook`, `YouTube`, `X`, `LinkedIn`, etc.): an object containing string keys representing platform account identifiers and integer values representing the index of the associated entry. A key must be a valid URL path that points to an account URL when concatenated with the platform's canonical URL. For example, the `Facebook` object could contain the key/value pair "`exampleuser`: 45", where the `source.entry[45]` would represent the entity associated with `https://www.facebook.com/exampleuser`.
+
+  ### Using trust.txt files
+
+  The [`trust.txt` specification](https://journallist.net/reference-document-for-trust-txt-specifications) defines a machine-readable text file hosted on a publisher’s domain, which provides information about the publisher’s affiliations, owned media properties, and connections with industry organizations. The `trust.txt` file offers similar functionality as a XPOC manifest. The browser extension can also detect the presence of a trust URI (for example, `trust://example.com!`) file on a visited page, and check if the page is listed in the corresponding `trust.txt` file on the origin domain.
+
+  

--- a/samples/browser-extension/src/content.ts
+++ b/samples/browser-extension/src/content.ts
@@ -255,7 +255,7 @@ function nodeTest(node: Node): boolean {
     ) {
         return false;
     }
-    return XPOC_PATTERN.test(node.textContent);
+    return XPOC_PATTERN.test(node.textContent) || TRUSTTXT_PATTERN.test(node.textContent);
 }
 
 function addCallback(node: Node): void {

--- a/samples/browser-extension/src/content.ts
+++ b/samples/browser-extension/src/content.ts
@@ -212,15 +212,15 @@ function showXpocPopup(targetNode: Node, xpocResult: lookupXpocUriResult) {
 
     if (xpocResult.type === 'account') {
         if (xpocResult.version === 'trust.txt1.4') {
+            const platformMessage = xpocResult.account.platform ? `${xpocResult.account.platform} account ${xpocResult.account.account}` : `Account ${xpocResult.account.account}`;
             contentPopup.show(
                 targetNode as HTMLElement,
-                'Trust.txt Information',
+                'Trust.txt match',
                 SUCCESS_COLOR,
                 chrome.runtime.getURL('icons/xpoc_logo.svg'),
                 [
                     {
-                        title: 'Trust.txt match',
-                        Message: `${xpocResult.account.platform} account ${xpocResult.account.account} found in trust.txt file at ${xpocResult.baseurl}`
+                        Message: `${platformMessage} found in trust.txt file at ${xpocResult.baseurl}`
                     }
                 ],
             );

--- a/samples/browser-extension/src/content.ts
+++ b/samples/browser-extension/src/content.ts
@@ -114,10 +114,8 @@ const addIcon = (node: Node) => {
         }
 
         // Check if the node contains an XPOC URI
-        console.log(`checking node for xpoc: ${node.textContent}`) // FIXME: delete
         const match = XPOC_PATTERN.exec((node as Text).textContent ?? '');
         const xpocUri = match?.[0] as string;
-        // cache.set(node, xpocUri);
 
         lookupXpocUri(xpocUri).then((result) => {
             const icon = new Icon(node, xpocUri, result);
@@ -129,10 +127,8 @@ const addIcon = (node: Node) => {
         });
 
         // Check if the node contains a Trust.txt URI
-        console.log(`checking node for trust.txt: ${node.textContent}`) // FIXME: delete
         const trustMatch = TRUSTTXT_PATTERN.exec((node as Text).textContent ?? '');
         const trustUri = trustMatch?.[0] as string;
-        // cache.set(node, trustUri);
 
         lookupTrustUri(trustUri).then((result) => {
             const icon = new Icon(node, trustUri, result);
@@ -211,7 +207,7 @@ function showXpocPopup(targetNode: Node, xpocResult: lookupXpocUriResult) {
     }
 
     if (xpocResult.type === 'account') {
-        if (xpocResult.version === 'trust.txt1.4') {
+        if (xpocResult.version === 'trust.txt-draft00') {
             const platformMessage = xpocResult.account.platform ? `${xpocResult.account.platform} account ${xpocResult.account.account}` : `Account ${xpocResult.account.account}`;
             contentPopup.show(
                 targetNode as HTMLElement,

--- a/samples/browser-extension/src/offscreen.ts
+++ b/samples/browser-extension/src/offscreen.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { lookupXpocUri } from './xpoc-lib.js';
+import { lookupXpocUri, lookupTrustUri } from './xpoc-lib.js';
 
 console.log('offscreen.js loaded');
 
@@ -25,6 +25,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
     if (request?.type === 'lookupXpocUri') {
         lookupXpocUri(request.tabUrl, request.url).then((result) => {
+            sendResponse(result);
+        });
+    } else if (request?.type === 'lookupTrustUri') {
+        lookupTrustUri(request.tabUrl, request.url).then((result) => {
             sendResponse(result);
         });
     }

--- a/samples/browser-extension/src/xpoc-lib-proxy.ts
+++ b/samples/browser-extension/src/xpoc-lib-proxy.ts
@@ -9,6 +9,12 @@ type lookupXpocUriMessage = {
     tabUrl: string;
 };
 
+type lookupTrustUriMessage = {
+    type: 'lookupTrustUri';
+    url: string;
+    tabUrl: string;
+};
+
 /*
   Create the offscreen document when the background script is loaded.  
   When background.js is a service worker (Chrome w/ Manifest V3), the offscreen document 
@@ -50,6 +56,23 @@ export async function lookupXpocUri(
     return await offscreenMessage<lookupXpocUriMessage, lookupXpocUriResult>({
         type: 'lookupXpocUri',
         url: xpocUrl,
+        tabUrl: tabUrl,
+    });
+}
+
+/**
+ * Looks up the trust.txt URI for a given tab URL and trust.txt URL.
+ * @param tabUrl The URL of the tab.
+ * @param trustUrl The URL of the trust.txt.
+ * @returns A promise that resolves to the result of the lookup.
+ */
+export async function lookupTrustUri(
+    tabUrl: string,
+    trustUrl: string,
+): Promise<lookupXpocUriResult> {
+    return await offscreenMessage<lookupTrustUriMessage, lookupXpocUriResult>({
+        type: 'lookupTrustUri',
+        url: trustUrl,
         tabUrl: tabUrl,
     });
 }

--- a/samples/browser-extension/src/xpoc-lib.ts
+++ b/samples/browser-extension/src/xpoc-lib.ts
@@ -451,7 +451,7 @@ export async function lookupTrustUri(
             type: 'account',
             name: domain,
             baseurl: domain,
-            version: 'trust.txt1.4',
+            version: 'trust.txt-draft00',
             account: {
                 account: account,
                 platform: platform

--- a/samples/browser-extension/src/xpoc-lib.ts
+++ b/samples/browser-extension/src/xpoc-lib.ts
@@ -19,7 +19,7 @@ const DOWNLOAD_TIMEOUT = Number.parseInt(
  * @param url - The input URL.
  * @returns The base URL.
  */
-function getBaseURL(url: string) {
+export function getBaseURL(url: string) {
     const urlObj = new URL(url);
     const searchParams = urlObj.searchParams;
     const queryParams: string[] = [];
@@ -243,4 +243,191 @@ export async function lookupXpocUri(
 
     console.log('Content not found in manifest');
     return { type: 'notFound', baseurl: manifest.baseurl };
+}
+
+/*
+ * Trust.txt handlers (tried to put that in its own file but bundler would need updating)
+ */
+
+/**
+ * A trust.txt file.
+ */
+export type TrustTxtFile = {
+    member: string[];
+    belongto: string[];
+    control: string[];
+    controlledby: string[];
+    social: string[];
+    vendor: string[];
+    customer: string[];
+    disclosure: string[];
+    contact: string[];
+    datatrainingallowed: boolean;
+};
+
+/**
+ * Downloads the trust.txt file for the given trust URI.
+ * @param trustUri The trust URI.
+ * @returns A promise that resolves to the downloaded trust.txt file or an Error object if the URI is invalid.
+ */
+async function downloadTrustTxt(
+    trustUri: string,
+): Promise<TrustTxtFile | Error> {
+    if (!trustUri.startsWith('trust://')) {
+        return new Error(`Invalid trust URI: ${trustUri}`);
+    }
+
+    const trustUrl =
+        trustUri
+            // replace the trust:// prefix with https://
+            .replace(/^trust:\/\//, 'https://')
+            // remove trailing !
+            .replace(/!$/, '')
+            // remove trailing slash, if present
+            .replace(/\/$/, '') +
+        // append the trust.txt path
+        '/trust.txt';
+
+    const trustTxtContent = await fetchWithTimeout<string>(trustUrl);
+    if (trustTxtContent instanceof Error) {
+        return trustTxtContent;
+    }
+    const trustTxtFile = parseTrustTxt(trustTxtContent);
+    return trustTxtFile;
+}
+
+function parseTrustTxt(trustTxtContent: string): TrustTxtFile {
+    const trustTxtFile: TrustTxtFile = {
+        member: [],
+        belongto: [],
+        control: [],
+        controlledby: [],
+        social: [],
+        vendor: [],
+        customer: [],
+        disclosure: [],
+        contact: [],
+        datatrainingallowed: false
+    }
+
+    const lines = trustTxtContent.split('\n');
+    for (const line of lines) {
+        const cleanedLine = line.trim();
+
+        // Skip empty lines and comments
+        if (!cleanedLine || cleanedLine.startsWith('#')) {
+            continue;
+        }
+
+        const [variable, value] = cleanedLine.split('=');
+
+        if (!variable || !value) {
+            continue;
+        }
+
+        const cleanedVariable = variable.trim().toLowerCase();
+        const trimmedValue = value.trim();
+
+        switch (cleanedVariable) {
+            case 'member':
+                trustTxtFile.member.push(trimmedValue);
+                break;
+            case 'belongto':
+                trustTxtFile.belongto.push(trimmedValue);
+                break;
+            case 'control':
+                trustTxtFile.control.push(trimmedValue);
+                break;
+            case 'controlledby':
+                trustTxtFile.controlledby.push(trimmedValue);
+                break;
+            case 'social':
+                trustTxtFile.social.push(trimmedValue);
+                break;
+            case 'vendor':
+                trustTxtFile.vendor.push(trimmedValue);
+                break;
+            case 'customer':
+                trustTxtFile.customer.push(trimmedValue);
+                break;
+            case 'disclosure':
+                trustTxtFile.disclosure.push(trimmedValue);
+                break;
+            case 'contact':
+                trustTxtFile.contact.push(trimmedValue);
+                break;
+            case 'datatrainingallowed':
+                trustTxtFile.datatrainingallowed = trimmedValue.toLowerCase() === 'yes';
+                break;
+            default:
+                console.warn(`Unknown variable: ${cleanedVariable}`);
+        }
+    }
+
+    return trustTxtFile;
+}
+
+/**
+ * Looks up the trust URI for a given tab URL and trust URL.
+ * @param tabUrl The URL of the tab.
+ * @param xpocUrl The URL of the trust.txt file.
+ * @returns A promise that resolves to the lookup result.
+ */
+export async function lookupTrustUri(
+    tabUrl: string,
+    trustUrl: string,
+): Promise<lookupXpocUriResult> {
+    console.log('lookupTrustUri called', tabUrl, trustUrl);
+    const trustTxtFile = await downloadTrustTxt(trustUrl);
+
+    if (trustTxtFile instanceof Error) {
+        console.log('Error fetching trust.txt file:', trustTxtFile.message);
+        return {
+            type: 'error',
+            baseurl: trustUrl,
+            message: `Error fetching trust.txt file: ${trustTxtFile.message}`,
+        };
+    }
+
+    // check each trust.txt file social account to see if it matches the current tab url
+    tabUrl = getBaseURL(tabUrl as string);
+    const matchingAccountUrl = trustTxtFile.social?.find((account: string) => {
+        // get the platform object for this account
+        const platform = Platforms.isSupportedAccountUrl(account)
+            ? Platforms.getPlatformFromAccountUrl(account)
+            : undefined;
+        if (platform && platform?.isValidAccountUrl(tabUrl)) {
+            const canonicalizedTabUrl = platform.canonicalizeAccountUrl(tabUrl);
+            const canonicalizedAccountUrl = platform.canonicalizeAccountUrl(account);
+            return (
+                canonicalizedTabUrl.account === canonicalizedAccountUrl.account
+            );
+        }
+        // tab url possibly matches this account but is not a supported platform
+        else {
+            if (tabUrl === getBaseURL(account)) {
+                return true;
+            }
+        }
+        return false;
+    });
+
+    if (matchingAccountUrl) {
+        console.log('Content found in trust.txt file', matchingAccountUrl);
+        const platform = Platforms.getPlatformFromAccountUrl(matchingAccountUrl)?.DisplayName || 'Unknown';
+        return {
+            type: 'account',
+            name: trustUrl, // TODO: change?
+            baseurl: trustUrl, // TODO: change?
+            version: 'trust.txt1.4',
+            account: {
+                account: matchingAccountUrl,
+                platform: platform
+
+            }
+        };
+    }
+
+    console.log('Content not found in manifest');
+    return { type: 'notFound', baseurl: trustUrl };
 }

--- a/samples/browser-extension/test/trust.txt.html
+++ b/samples/browser-extension/test/trust.txt.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <title>Extension Test Page Trust.txt</title>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+</head>
+
+<body>
+
+    <div>
+        <h1>Extension Test Page</h1>
+        <p>Test various ways the trust.txt link could be added/removed from a page</p>
+    </div>
+
+    <div id="test-1">
+        <h3>Static link present on in html</h3>
+        <details>The trust link is part of the downloaded HTML page</details>
+        <p>trust://christianpaquin.github.io!</p>
+    </div>
+
+</body>
+
+</html>


### PR DESCRIPTION
Adds support for [trust.txt files](https://[journallist.net/trust.txt](https://journallist.net/trust.txt)), by looking up `trust://` URIs (like the `xpox://` ones) and checking if the current page is listed as a `social` account in the corresponding `trust.txt` file. [Demo video](https://www.youtube.com/watch?v=CR0GeOxT7Fs).