### PR TITLE
Disabled youtube content retrieval tests

### DIFF
--- a/lib/test/platform.test.ts
+++ b/lib/test/platform.test.ts
@@ -928,6 +928,10 @@ for (const platformTestData of platformTestDataArray) {
             test(`${platformName} content fetch test`, async () => {
                 const sampleContent = platformTestData.sampleContentData;
                 if (sampleContent) {
+                    if (sampleContent.platform === 'YouTube') {
+                        // Disabling YouTube retrieval test; they fail on CI but work locally (presumably due to IP restrictions)
+                        return;
+                    }
                     const contentData = await platform.getContentData(
                         sampleContent.url,
                     );
@@ -1270,10 +1274,14 @@ describe('platform operations', () => {
     });
 
     test('platform content URL extraction', async () => {
+        let url = '';
+        let contentData;
+
+        /* Disabling YouTube retrieval test; they fail on CI but work locally (presumably due to IP restrictions) 
         // YouTube test
-        let url = 'https://www.youtube.com/watch?v=hDd3t7y1asU';
+        url = 'https://www.youtube.com/watch?v=hDd3t7y1asU';
         expect(Platforms.canFetchContentFromUrl(url)).toBe(true);
-        let contentData = await Platforms.getContentFromUrl(url);
+        contentData = await Platforms.getContentFromUrl(url);
         expect(contentData.platform).toBe('YouTube');
         expect(contentData.puid).toBe('hDd3t7y1asU');
         expect(contentData.url).toBe(
@@ -1284,6 +1292,7 @@ describe('platform operations', () => {
         expect(contentData.timestamp.substring(0, 'YYYY-MM-DD'.length)).toBe(
             '2023-07-10',
         );
+        */
 
         // X/Twitter test (no public access, expect a not supported exception)
         url = 'https://twitter.com/chpaquin/status/1694698274618319246';


### PR DESCRIPTION
YouTube content retrieval tests are working locally but failing on CI, presumable due to IP restrictions. Disabling them